### PR TITLE
Update rempl version in order to fix `initRemoteDevtoolAPI` method

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "minimatch": "~3.0.2",
     "open-in-editor": "^2.1.0",
     "pem": "^1.9.4",
-    "rempl": "1.0.0-alpha10",
+    "rempl": "1.0.0-alpha11",
     "resolve": "1.1.7",
     "socket.io": "~1.7.3",
     "socket.io-client": "~1.7.3",


### PR DESCRIPTION
In `1.0.0-alpha10` `initRemoteDevtoolAPI` looks like this:
```
api.initRemoteDevtoolAPI = function() {
    console.warn('initRemoteDevtoolAPI() method is deprecated, use initRemotePublisher() instead');
};
```

basis.js expect `initRemoteDevtoolAPI` to return `setFeatures` method, but it don't.
Issue has been fixed in `1.0.0-alpha11`